### PR TITLE
Fix pokemon parsing, modify delay for pokesnipers, reuse of code

### DIFF
--- a/PogoLocationFeeder.sln
+++ b/PogoLocationFeeder.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PogoLocationFeeder", "PogoLocationFeeder\PogoLocationFeeder.csproj", "{76F6EEEF-E89F-4E43-AA9D-1567CBC1420B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PogoLocationFeederTests", "PogoLocationFeederTests\PogoLocationFeederTests.csproj", "{7411B812-CF4C-4BD2-84B4-09EBD6D08DA4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{76F6EEEF-E89F-4E43-AA9D-1567CBC1420B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{76F6EEEF-E89F-4E43-AA9D-1567CBC1420B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{76F6EEEF-E89F-4E43-AA9D-1567CBC1420B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7411B812-CF4C-4BD2-84B4-09EBD6D08DA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7411B812-CF4C-4BD2-84B4-09EBD6D08DA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7411B812-CF4C-4BD2-84B4-09EBD6D08DA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7411B812-CF4C-4BD2-84B4-09EBD6D08DA4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/PogoLocationFeeder/Config/Settings.cs
+++ b/PogoLocationFeeder/Config/Settings.cs
@@ -13,6 +13,7 @@ namespace PoGo.LocationFeeder.Settings
     public class GlobalSettings
     {
         //public ulong ServerId = 206065054846681088;
+        public List<string> ServerChannels = new List<string> { "coord-bot", "coords_bot", "coordsbots", "90_plus_iv", "90plus_ivonly", "rare_spottings", "high_iv_pokemon", "rare_pokemon" };
         public string DiscordToken = "";
         public int Port = 16969;
         public bool useToken = false;

--- a/PogoLocationFeeder/Helper/GeoCoordinatesParser.cs
+++ b/PogoLocationFeeder/Helper/GeoCoordinatesParser.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace PogoLocationFeeder.Helper
+{
+    public class GeoCoordinatesParser
+    {
+        public static GeoCoordinates parseGeoCoordinates(string input)
+        {
+            Match match = Regex.Match(input, @"(?<lat>\-?\d+[\,|\.]\d+)[,|\s]*(?<long>\-?\d+[\,|\.]\d+)");
+            if (match.Success)
+            {
+                GeoCoordinates geoCoordinates = new GeoCoordinates();
+                geoCoordinates.latitude = Convert.ToDouble(match.Groups["lat"].Value.Replace(',', '.'), CultureInfo.InvariantCulture);
+                geoCoordinates.longitude = Convert.ToDouble(match.Groups["long"].Value.Replace(',', '.'), CultureInfo.InvariantCulture);
+                return geoCoordinates;
+            }
+            return null;
+        }
+    }
+
+   public class GeoCoordinates
+    {
+        public double latitude { get; set; }
+        public double longitude { get; set; }
+     }
+}

--- a/PogoLocationFeeder/Helper/MessageParser.cs
+++ b/PogoLocationFeeder/Helper/MessageParser.cs
@@ -1,9 +1,8 @@
-﻿using POGOProtos.Enums;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
-
+using POGOProtos.Enums;
 namespace PogoLocationFeeder.Helper
 {
     internal class MessageParser
@@ -17,15 +16,21 @@ namespace PogoLocationFeeder.Helper
             foreach (var input in lines)
             {
                 sniperInfo = new SniperInfo();
-                if (!parseGeoCoordinates(input))
+                GeoCoordinates geoCoordinates = GeoCoordinatesParser.parseGeoCoordinates(input);
+                if (geoCoordinates == null)
                 {
                     //Console.WriteLine($"Can't get coords from line: {input}"); // debug output, too much spam
                     continue;
                 }
+                else
+                {
+                    sniperInfo.latitude = geoCoordinates.latitude;
+                    sniperInfo.longitude = geoCoordinates.longitude;
+                }
                 parseIV(input);
                 parseTimestamp(input);
-                parsePokemonId(input);
-
+                PokemonId pokemon = PokemonParser.parsePokemon(input);
+                sniperInfo.id = pokemon;
                 snipeList.Add(sniperInfo);
             }
 
@@ -101,40 +106,5 @@ namespace PogoLocationFeeder.Helper
             }
         }
 
-        private void parsePokemonId(string input)
-        {
-            if (input.IndexOf("Kadabra", StringComparison.OrdinalIgnoreCase) >= 0) // kadabra = abra
-            {
-                sniperInfo.id = PokemonId.Kadabra;
-                return;
-            }
-            else
-            if (input.IndexOf("Kabutops", StringComparison.OrdinalIgnoreCase) >= 0) // Kabutops = Kabuto
-            {
-                sniperInfo.id = PokemonId.Kadabra;
-                return;
-            }
-            else
-            if (input.IndexOf("Farfetch", StringComparison.OrdinalIgnoreCase) >= 0)
-            {
-                sniperInfo.id = PokemonId.Farfetchd;
-                return;
-            }
-
-            foreach (string name in Enum.GetNames(typeof(PokemonId)))
-            {
-                if (input.IndexOf(name, StringComparison.OrdinalIgnoreCase) >= 0)
-                {
-                    sniperInfo.id = (PokemonId)Enum.Parse(typeof(PokemonId), name);
-                    return;
-                }
-            }
-
-            if (input.IndexOf("Mime", StringComparison.OrdinalIgnoreCase) >= 0)
-            {
-                sniperInfo.id = PokemonId.MrMime;
-                return;
-            }
-        }
     }
 }

--- a/PogoLocationFeeder/Helper/PokemonParser.cs
+++ b/PogoLocationFeeder/Helper/PokemonParser.cs
@@ -1,0 +1,92 @@
+﻿using POGOProtos.Enums;
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace PogoLocationFeeder
+{
+
+    public class PokemonParser
+    {
+        static List<PokemonAlternativeNames> pokemonAlternativeNamesList = new List<PokemonAlternativeNames>()
+        {
+            { PokemonAlternativeNames.createAllMatches(PokemonId.Farfetchd, new HashSet<String> { "Farfetch'd" }, new HashSet<String> { "Farfetch" })},
+            { PokemonAlternativeNames.createAllMatches(PokemonId.MrMime,  new HashSet<String> { "mr.Mime", "mr mime" }, new HashSet<String> { "Mime" })},
+        };
+
+        public static PokemonId parsePokemon(string input)
+        {
+            foreach (string name in Enum.GetNames(typeof(PokemonId)))
+            {
+                if (matchesPokemonNameExactly(input, name))
+                {
+                    return (PokemonId)Enum.Parse(typeof(PokemonId), name);
+                }
+            }
+            foreach (PokemonAlternativeNames pokemonAlternativeNames in pokemonAlternativeNamesList)
+            {
+                if(pokemonAlternativeNames.exactMatches != null)
+                {
+                    foreach(String exactMatch in pokemonAlternativeNames.exactMatches)
+                    {
+                        if(matchesPokemonNameExactly(input, exactMatch))
+                        {
+                            return pokemonAlternativeNames.pokemonId;
+                        }
+                    }
+                }
+                if (pokemonAlternativeNames.partialMatches != null)
+                {
+                    foreach (String partialMatch in pokemonAlternativeNames.partialMatches)
+                    {
+                        if (matchesPokemonNamePartially(input, partialMatch))
+                        {
+                            return pokemonAlternativeNames.pokemonId;
+                        }
+                    }
+                }
+            }
+
+
+            return PokemonId.Missingno;
+        }
+
+        private static bool matchesPokemonNameExactly(String input, String name)
+        {
+            return Regex.IsMatch(input, @"(?i)\b" + name + @"\b");
+        }
+
+        private static bool matchesPokemonNamePartially(String input, String name)
+        {
+            return Regex.IsMatch(input, @"(?i)" + name);
+        }
+
+        internal class PokemonAlternativeNames
+        {
+            internal PokemonId pokemonId { get; }
+            internal ISet<String> exactMatches { get; }
+            internal ISet<String> partialMatches { get; }
+
+            internal PokemonAlternativeNames(PokemonId pokemonId, ISet<String> exactMatches, ISet<String> partialMatches)
+            {
+                this.pokemonId = pokemonId;
+                this.exactMatches = exactMatches;
+                this.partialMatches = partialMatches;
+            }
+
+            internal static PokemonAlternativeNames createAllMatches(PokemonId pokemonId, ISet<String> exactMatches, ISet<String> partialMatches)
+            {
+                return new PokemonAlternativeNames(pokemonId, exactMatches, partialMatches);
+            }
+            internal static PokemonAlternativeNames createPartialMatches(PokemonId pokemonId, ISet<String> partialMatches)
+            {
+                return new PokemonAlternativeNames(pokemonId, null, partialMatches);
+            }
+
+            internal static PokemonAlternativeNames createExactMatches(PokemonId pokemonId, ISet<String> exactMatches)
+            {
+                return new PokemonAlternativeNames(pokemonId, exactMatches, null);
+            }
+        }
+    }
+}

--- a/PogoLocationFeeder/PogoLocationFeeder.csproj
+++ b/PogoLocationFeeder/PogoLocationFeeder.csproj
@@ -100,6 +100,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Helper\GeoCoordinatesParser.cs" />
+    <Compile Include="Helper\PokemonParser.cs" />
     <Compile Include="PokeSniperReader.cs" />
     <Compile Include="Config\Settings.cs" />
     <Compile Include="Helper\MessageParser.cs" />

--- a/PogoLocationFeeder/Program.cs
+++ b/PogoLocationFeeder/Program.cs
@@ -156,7 +156,7 @@ namespace PogoLocationFeeder
 
         private void pollPokesniperFeed()
         {
-            int delay = 15 * 1000;
+            int delay = 30 * 1000;
             var cancellationTokenSource = new CancellationTokenSource();
             var token = cancellationTokenSource.Token;
             var listener = Task.Factory.StartNew(async () =>
@@ -165,16 +165,25 @@ namespace PogoLocationFeeder
                 while (true)
                 {
                     Thread.Sleep(delay);
-                    var pokeSniperList = await pokeSniperReader.readAll();
-                    if (pokeSniperList != null)
+                    for (int retrys = 0; retrys <= 3; retrys++)
                     {
-                        await feedToClients(pokeSniperList, "PokeSniper");
+                        var pokeSniperList = await pokeSniperReader.readAll();
+                        if (pokeSniperList != null)
+                        {
+                            if(pokeSniperList.Any()) {
+                                await feedToClients(pokeSniperList, "PokeSnipers");
+                            } else
+                            {
+                                Console.WriteLine("No new pokemon on PokeSnipers");
+                            }
+                            break;
+                        }
+                        if (token.IsCancellationRequested)
+                            break;
+                        Thread.Sleep(1000);
                     }
-                    if (token.IsCancellationRequested)
-                        break;
                 }
 
-                //cleanup
             }, token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
         }
     }

--- a/PogoLocationFeeder/SniperInfo.cs
+++ b/PogoLocationFeeder/SniperInfo.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using POGOProtos.Enums;
+
 
 namespace PogoLocationFeeder
 {

--- a/PogoLocationFeederTests/GeoCoordinatesParserTest.cs
+++ b/PogoLocationFeederTests/GeoCoordinatesParserTest.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PogoLocationFeeder.Helper;
+
+namespace PogoLocationFeederTests
+{
+    [TestClass]
+    public class GeoCoordinatesParserTest
+    {
+        
+        [TestMethod]
+        public void TestCoordinatesCoordBot()
+        {
+             testCoordinates("[192 seconds remaining] 55% IV - Porygon at 48.880245472813,2.3258381797353 [Moveset: TackleFast/Psybeam]", 48.880245472813, 2.3258381797353);
+        }
+
+        [TestMethod]
+        public void TestCoordinatesRandomPerson1()
+        {
+            testCoordinates("50.846499257055854,4.421932697296143 Lapras 11min 92IV Frosth Breath Dragon Pulse", 50.846499257055854, 4.421932697296143);
+        }
+
+        [TestMethod]
+        public void TestCoordinatesRandomPerson2()
+        {
+            testCoordinates("34.0392682838917,-118.494653181811, Eevee, 10min", 34.0392682838917, -118.494653181811);
+        }
+
+        [TestMethod]
+        public void TestCoordinatesPokeSniper()
+        {
+            testCoordinates("-33.8304880738,151.087396206",-33.8304880738, 151.087396206);
+        }
+
+        private void testCoordinates(String text, Double expectedLatitude, Double expectedLongitude)
+        {
+            GeoCoordinates geoCoordinates = GeoCoordinatesParser.parseGeoCoordinates(text);
+            Assert.IsNotNull(geoCoordinates);
+            Assert.AreEqual(expectedLatitude, geoCoordinates.latitude);
+            Assert.AreEqual(expectedLongitude, geoCoordinates.longitude);
+        }
+    }
+}

--- a/PogoLocationFeederTests/Helper/PokemonParserTests.cs
+++ b/PogoLocationFeederTests/Helper/PokemonParserTests.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PogoLocationFeeder;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using POGOProtos.Enums;
+
+namespace PogoLocationFeeder.Tests
+{
+    [TestClass()]
+    public class PokemonParserTests
+    {
+        [TestMethod()]
+        public void parsePokemonTest()
+        {
+            testPokemonParsing("kadabra", PokemonId.Kadabra);
+            testPokemonParsing("Kadabra", PokemonId.Kadabra);
+            testPokemonParsing("abra", PokemonId.Abra);
+            testPokemonParsing("Mr Mime", PokemonId.MrMime);
+            testPokemonParsing("Mr.Mime", PokemonId.MrMime);
+            testPokemonParsing("MrMime", PokemonId.MrMime);
+            testPokemonParsing("farfetchd", PokemonId.Farfetchd);
+            testPokemonParsing("farfetch'd", PokemonId.Farfetchd);
+            testPokemonParsing("farfetched", PokemonId.Farfetchd);
+            testPokemonParsing("Blastoise", PokemonId.Blastoise);
+            testPokemonParsing("qsddqfsfqds", PokemonId.Missingno);
+        }
+
+
+        [TestMethod()]
+        public void parsePokemonFullLine()
+        {
+            testPokemonParsing("[302 seconds remaining] 70% IV - Snorlax at 37.729738754701,-97.372969967814 [ Moveset: ZenHeadbuttFast/HyperBeam ]", PokemonId.Snorlax);
+            testPokemonParsing("[482 seconds remaining] 73% IV - Wigglytuff at 31.934567351007,-4.4561212903872 [ Moveset: FeintAttackFast/HyperBeam ]", PokemonId.Wigglytuff);
+            testPokemonParsing("52,6271480914, 13,2858625127 Magneton 90", PokemonId.Magneton);
+        }
+
+        private void testPokemonParsing(String text, PokemonId expectedPokemonId)
+        {
+            Assert.AreEqual(expectedPokemonId, PokemonParser.parsePokemon(text));
+        }
+    }
+}

--- a/PogoLocationFeederTests/Helper/PokemonParserTests.cs
+++ b/PogoLocationFeederTests/Helper/PokemonParserTests.cs
@@ -26,6 +26,8 @@ namespace PogoLocationFeeder.Tests
             testPokemonParsing("farfetched", PokemonId.Farfetchd);
             testPokemonParsing("Blastoise", PokemonId.Blastoise);
             testPokemonParsing("qsddqfsfqds", PokemonId.Missingno);
+            testPokemonParsing("Kabuto", PokemonId.Kabuto);
+            testPokemonParsing("Kabutops", PokemonId.Kabutops);
         }
 
 

--- a/PogoLocationFeederTests/PogoLocationFeederTests.csproj
+++ b/PogoLocationFeederTests/PogoLocationFeederTests.csproj
@@ -1,0 +1,95 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7411B812-CF4C-4BD2-84B4-09EBD6D08DA4}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>PogoLocationFeederTests</RootNamespace>
+    <AssemblyName>PogoLocationFeederTests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="POGOProtos, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\POGOProtos.1.4.0\lib\net45\POGOProtos.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="GeoCoordinatesParserTest.cs" />
+    <Compile Include="Helper\PokemonParserTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\PogoLocationFeeder\PogoLocationFeeder.csproj">
+      <Project>{76F6EEEF-E89F-4E43-AA9D-1567CBC1420B}</Project>
+      <Name>PogoLocationFeeder</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/PogoLocationFeederTests/Properties/AssemblyInfo.cs
+++ b/PogoLocationFeederTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("PogoLocationFeederTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("PogoLocationFeederTests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("7411b812-cf4c-4bd2-84b4-09ebd6d08da4")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
Extracting some parsing class so they can be reused for the PokeSnipers
code.
Extract GeoCoordinatesParser
Extract PokemonParser
Wrote tests on both, the current pokemon parsing was failing (abra =>
kadabra)
Now using regex's to find them.
Easy to add alternative names for pokemons now.
Based on l3uddz pull request:
Add retry when the pokeSnipers doesn't respond. (3 retries max)
Set the delay to 30 seconds for pokesnipers request.