### PR TITLE
Ignoring duplicate coordinates across channels / servers

### DIFF
--- a/PogoLocationFeeder/Helper/MessageParser.cs
+++ b/PogoLocationFeeder/Helper/MessageParser.cs
@@ -75,28 +75,28 @@ namespace PogoLocationFeeder.Helper
                 Match match = Regex.Match(input, @"(\d+)\s?sec", RegexOptions.IgnoreCase);
                 if (match.Success)
                 {
-                    sniperInfo.timeStamp = DateTime.Now.AddSeconds(Convert.ToDouble(match.Groups[1].Value));
+                    sniperInfo.expirationTime = DateTime.Now.AddSeconds(Convert.ToDouble(match.Groups[1].Value));
                     return;
                 }
 
                 match = Regex.Match(input, @"(\d+)\s?min", RegexOptions.IgnoreCase);
                 if (match.Success)
                 {
-                    sniperInfo.timeStamp = DateTime.Now.AddMinutes(Convert.ToDouble(match.Groups[1].Value));
+                    sniperInfo.expirationTime = DateTime.Now.AddMinutes(Convert.ToDouble(match.Groups[1].Value));
                     return;
                 }
 
                 match = Regex.Match(input, @"(\d+)m\s?(\d+)s", RegexOptions.IgnoreCase); // Aerodactyl | 14m 9s | 34.008105111711,-118.49775510959
                 if (match.Success)
                 {
-                    sniperInfo.timeStamp = DateTime.Now.AddMinutes(Convert.ToDouble(match.Groups[1].Value)).AddSeconds(Convert.ToDouble(match.Groups[2].Value));
+                    sniperInfo.expirationTime = DateTime.Now.AddMinutes(Convert.ToDouble(match.Groups[1].Value)).AddSeconds(Convert.ToDouble(match.Groups[2].Value));
                     return;
                 }
 
                 match = Regex.Match(input, @"(\d+)\s?s\s", RegexOptions.IgnoreCase); // Lickitung | 15s | 40.69465351234,-73.99434315197
                 if (match.Success)
                 {
-                    sniperInfo.timeStamp = DateTime.Now.AddSeconds(Convert.ToDouble(match.Groups[1].Value));
+                    sniperInfo.expirationTime = DateTime.Now.AddSeconds(Convert.ToDouble(match.Groups[1].Value));
                     return;
                 }
             }

--- a/PogoLocationFeeder/PokeSniperReader.cs
+++ b/PogoLocationFeeder/PokeSniperReader.cs
@@ -92,7 +92,7 @@ namespace PogoLocationFeeder
                 sniperInfo.longitude = geoCoordinates.longitude;
             }
 
-            sniperInfo.timeStamp = Convert.ToDateTime(result.until);
+            sniperInfo.expirationTime = Convert.ToDateTime(result.until);
             return sniperInfo;
         }
 

--- a/PogoLocationFeeder/SniperInfo.cs
+++ b/PogoLocationFeeder/SniperInfo.cs
@@ -9,7 +9,13 @@ namespace PogoLocationFeeder
         public double latitude { get; set; }
         public double longitude { get; set; }
         public double iv { get; set; }
-        public DateTime timeStamp { get; set; }
+        public DateTime expirationTime { get; set; }
+        public DateTime creationTime { get; set; }
         public PokemonId id { get; set; }
+
+        public SniperInfo()
+        {
+            creationTime = DateTime.Now;
+        }
     }
 }


### PR DESCRIPTION
I was concerned with the amount of duplicate coordinates from my discord channels.
* Same coordinates from multiple servers
* Confirmation messages ("Confirmed", "Fake", ...) parsed as additional coordinates

This commit introduces a `sentMessages` List which is used to compare messages before they are "fed" to the clients. Messages are removed from the list after 1 minute to avoid memory growth over time.

To help with readability, the `timeStamp` property is renamed and another timestamp is introduced, which is created in a constructor.