### PR TITLE
Bi-directional communication with bot

### DIFF
--- a/PogoLocationFeeder/Config/Settings.cs
+++ b/PogoLocationFeeder/Config/Settings.cs
@@ -82,10 +82,12 @@ namespace PoGo.LocationFeeder.Settings
 
     public class EchoEncounter
     {
-        public string Format = "{0:0.00000000},{1:0.00000000} {2:0.00}% IV {3}";
+        public string Format = "{0:0.00000000},{1:0.00000000} {2:0.00}% IV {4} {5} {6}";
         public bool Always = false;
         public double MinimumIv = 0.0;
         public HashSet<PokemonId> Ids;
+        public HashSet<PokemonMove> Moves;
+        public int MovesToMatch = 0;
         public Dictionary<string, HashSet<string>> Channels;
     }
 }

--- a/PogoLocationFeeder/Config/Settings.cs
+++ b/PogoLocationFeeder/Config/Settings.cs
@@ -5,6 +5,7 @@ using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System.Collections.Generic;
+using POGOProtos.Enums;
 
 #endregion
 
@@ -14,6 +15,7 @@ namespace PoGo.LocationFeeder.Settings
     {
         //public ulong ServerId = 206065054846681088;
         public List<string> ServerChannels = new List<string> { "coord-bot", "coords_bot", "coordsbots", "90_plus_iv", "90plus_ivonly", "rare_spottings", "high_iv_pokemon", "rare_pokemon" };
+        public List<EchoEncounter> EchoEncounters = new List<EchoEncounter>();
         public string DiscordToken = "";
         public int Port = 16969;
         public bool useToken = false;
@@ -78,4 +80,12 @@ namespace PoGo.LocationFeeder.Settings
         }
     }
 
+    public class EchoEncounter
+    {
+        public string Format = "{0:0.00000000},{1:0.00000000} {2:0.00}% IV {3}";
+        public bool Always = false;
+        public double MinimumIv = 0.0;
+        public HashSet<PokemonId> Ids;
+        public Dictionary<string, HashSet<string>> Channels;
+    }
 }

--- a/PogoLocationFeeder/Helper/MessageParser.cs
+++ b/PogoLocationFeeder/Helper/MessageParser.cs
@@ -31,6 +31,11 @@ namespace PogoLocationFeeder.Helper
                 sniperInfo.iv = iv;
                 parseTimestamp(input);
                 PokemonId pokemon = PokemonParser.parsePokemon(input);
+                PokemonMove[] moves = PokemonParser.parsePokemonMoves(input);
+                if (moves.Length > 0)
+                    sniperInfo.move1 = moves[0];
+                if (moves.Length > 1)
+                    sniperInfo.move2 = moves[1];
                 sniperInfo.id = pokemon;
                 snipeList.Add(sniperInfo);
             }

--- a/PogoLocationFeeder/Helper/PokemonParser.cs
+++ b/PogoLocationFeeder/Helper/PokemonParser.cs
@@ -1,6 +1,7 @@
 ﻿using POGOProtos.Enums;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace PogoLocationFeeder
@@ -49,6 +50,11 @@ namespace PogoLocationFeeder
 
 
             return PokemonId.Missingno;
+        }
+
+        public static PokemonMove[] parsePokemonMoves(string input)
+        {
+            return Enum.GetValues(typeof (PokemonMove)).Cast<PokemonMove>().Where(move => Regex.IsMatch(input, "(?i)\b{move}\b")).ToArray();
         }
 
         private static bool matchesPokemonNameExactly(String input, String name)

--- a/PogoLocationFeeder/Program.cs
+++ b/PogoLocationFeeder/Program.cs
@@ -96,7 +96,7 @@ namespace PogoLocationFeeder
 
                     var info = JsonConvert.DeserializeObject<SniperInfo>(line);
 
-                    Console.WriteLine($"Encounter: ID: {info.id}, Lat:{info.latitude}, Lng:{info.longitude}, IV:{info.iv}");
+                    Console.WriteLine($"Encounter: ID: {info.id}, Lat:{info.latitude}, Lng:{info.longitude}, IV:{info.iv}, Move1:{info.move1}, Move2:{info.move2}");
 
                     // Make sure EchoSettings exists in the Settings
                     if (settings.EchoEncounters != null)
@@ -105,7 +105,8 @@ namespace PogoLocationFeeder
                         foreach (var entry in settings.EchoEncounters.Where(e =>
                             e.Always ||
                             ((e.MinimumIv < 0.1 || e.MinimumIv <= info.iv) &&
-                            (e.Ids == null || e.Ids.Contains(info.id)))))
+                            (e.Ids == null || e.Ids.Contains(info.id)) &&
+                            (e.MovesToMatch < 1 || e.Moves == null || (e.MovesToMatch <= (e.Moves.Contains(info.move1) ? 1 : 0) + (e.Moves.Contains(info.move2) ? 1 : 0))))))
                         {
                             // Format the message
                             string msg = string.Format(entry.Format, info.latitude, info.longitude, info.iv, info.timeStamp, info.id);

--- a/PogoLocationFeeder/Program.cs
+++ b/PogoLocationFeeder/Program.cs
@@ -104,8 +104,8 @@ namespace PogoLocationFeeder
                         // Find which entries match this Pokemon
                         foreach (var entry in settings.EchoEncounters.Where(e =>
                             e.Always ||
-                            e.MinimumIv <= info.iv ||
-                            (e.Ids != null && e.Ids.Contains(info.id))))
+                            ((e.MinimumIv < 0.1 || e.MinimumIv <= info.iv) &&
+                            (e.Ids == null || e.Ids.Contains(info.id)))))
                         {
                             // Format the message
                             string msg = string.Format(entry.Format, info.latitude, info.longitude, info.iv, info.timeStamp, info.id);

--- a/PogoLocationFeeder/Program.cs
+++ b/PogoLocationFeeder/Program.cs
@@ -122,6 +122,7 @@ namespace PogoLocationFeeder
                                 foreach (Channel c in server.TextChannels.Where(c => serverchannels.Value.Contains(c.Name)))
                                 {
                                     // Send the message!
+                                    Console.WriteLine($"Sending to #{c.Name} on {server.Name}");
                                     await c.SendMessage(msg);
                                 }
                             }

--- a/PogoLocationFeeder/SniperInfo.cs
+++ b/PogoLocationFeeder/SniperInfo.cs
@@ -11,6 +11,8 @@ namespace PogoLocationFeeder
         public double iv { get; set; }
         public DateTime timeStamp { get; set; }
         public PokemonId id { get; set; }
+        public PokemonMove move1 { get; set; }
+        public PokemonMove move2 { get; set; }
 
         public override string ToString()
         {
@@ -18,7 +20,9 @@ namespace PogoLocationFeeder
                 + ", latitude: " + latitude 
                 + ", longitude: " + longitude 
                 + (iv != default(double) ? ", IV: " + iv + "%" : "")
-                + (timeStamp != default (DateTime) ? ", expiration: " + timeStamp : "");
+                + (timeStamp != default (DateTime) ? ", expiration: " + timeStamp : "")
+                + (move1 != PokemonMove.MoveUnset ? ", move1: " + move1 : "")
+                + (move2 != PokemonMove.MoveUnset ? ", move2: " + move2 : "");
 
         }
     }


### PR DESCRIPTION
This branch enables bi-directional communication with [PokeMobBot after Pull Request 225](https://github.com/PocketMobsters/PokeMobBot/pull/225) which allows these bots to be turned into coordbots during normal operation (wild encounters and lure encounters). Settings are changed with a new element:
```
"EchoEncounters": [
    {
      "Format": "{0:0.00000000},{1:0.00000000} {2:0.00}% IV {4} {5} {6}",
      "Always": false,
      "MinimumIv": 90.0,
      "Ids": null,
      "Moves": null,
      "MovesToMatch": 0,
      "Channels": {
        "PokeMobBot": [
          "90_plus_iv",
          "locationsandroutes"
        ]
      }
    }
  ],
```
`Format` is a formatted string with the replaceable parameters 0: latitude, 1: longitude, 2: IV, 3: timestamp, 4: ID, 5: move 1, 6: move 2
`Always` means this rule will always match (should be used for testing only)
`MinimumIv` means this rule will match if IV is above a certain percentage
`Ids` means this rule will match only certain Pokemon
`Moves` means this rule will match certain Pokemon moves
`MovesToMatch` is the minimum number of listed moves (above) that must be present
`Channels` is an array with keys that match case-insensitive substrings of the servers you have access to, the the value is an array of the exact names of the channels in that server you want to broadcast to

One rule can be created to broadcast to multiple channels on multiple servers. If `MinimumIv` and `Ids` are both specified, then both must match ("and" behavior).