### PR TITLE
Added API Project

### DIFF
--- a/PogoLocationFeeder.API/PogoLocationFeeder.API.csproj
+++ b/PogoLocationFeeder.API/PogoLocationFeeder.API.csproj
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E82FE137-7326-4EFA-A4DD-A8592BF70F36}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>PogoLocationFeeder.API</RootNamespace>
+    <AssemblyName>PogoLocationFeeder.API</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="POGOProtos">
+      <HintPath>..\packages\POGOProtos.1.4.0\lib\net45\POGOProtos.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="PogoLocationFeederListener.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SniperInfoModel.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/PogoLocationFeeder.API/PogoLocationFeederListener.cs
+++ b/PogoLocationFeeder.API/PogoLocationFeederListener.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using System.Net.Sockets;
+using System.Threading;
+
+namespace PogoLocationFeeder.Api
+{
+    public class PogoLocationFeederListener
+    {
+        public delegate void PogoLocationFeederEventHandler(object sender, SniperInfoModel sniperInfo);
+
+        public event PogoLocationFeederEventHandler eventHandler;
+
+        public Task AsyncStart(string server, int port, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return Task.Run(() => Start(server, port, cancellationToken), cancellationToken);
+        }
+
+        private async Task Start(string server, int port, CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                try
+                {
+                    using (var lClient = new TcpClient())
+                    {
+                        lClient.Connect(server, port);
+                        using (var sr = new StreamReader(lClient.GetStream()))
+                        {
+                            while (lClient.Connected)
+                            {
+                                var line = sr.ReadLine();
+                                if (line == null)
+                                    throw new Exception("Unable to ReadLine from sniper socket");
+
+                                var info = JsonConvert.DeserializeObject<SniperInfoModel>(line);
+                                OnReceive(info);
+                            }
+                        }
+                    }
+                }
+                catch (SocketException)
+                {
+                    // this is spammed to often. Maybe add it to debug log later
+                }
+                catch (Exception)
+                {
+                    // most likely System.IO.IOException
+                }
+                await Task.Delay(5000, cancellationToken);
+            }
+        }
+
+        protected virtual void OnReceive(SniperInfoModel sniperInfo)
+        {
+            Task.Run(() =>
+            {
+                if (eventHandler != null)
+                {
+                    eventHandler(this, sniperInfo);
+                }
+            });
+        }
+
+    }
+}

--- a/PogoLocationFeeder.API/Properties/AssemblyInfo.cs
+++ b/PogoLocationFeeder.API/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("PogoLocationFeeder.API")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("PogoLocationFeeder.API")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e82fe137-7326-4efa-a4dd-a8592bf70f36")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/PogoLocationFeeder.API/SniperInfoModel.cs
+++ b/PogoLocationFeeder.API/SniperInfoModel.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+using POGOProtos.Enums;
+using System;
+
+namespace PogoLocationFeeder.Api
+{
+    public class SniperInfoModel
+    {
+        [JsonProperty("ExpirationTimestamp")]
+        public DateTime ExpirationTimestamp { get; set; }
+        [JsonProperty("Latitude")]
+        public double Latitude { get; set; }
+        [JsonProperty("Longitude")]
+        public double Longitude { get; set; }
+        [JsonProperty("Id")]
+        public PokemonId Id { get; set; } = PokemonId.Missingno;
+        [JsonProperty("IV")]
+        public double IV { get; set; }
+    }
+}

--- a/PogoLocationFeeder.API/app.config
+++ b/PogoLocationFeeder.API/app.config
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+</configuration>

--- a/PogoLocationFeeder.API/packages.config
+++ b/PogoLocationFeeder.API/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Google.Protobuf" version="3.0.0-beta4" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="pogo" version="0.0.3" targetFramework="net452" />
+  <package id="protobuf40" version="3.0.0" targetFramework="net452" />
+</packages>

--- a/PogoLocationFeeder.GUI/PogoLocationFeeder.GUI.csproj
+++ b/PogoLocationFeeder.GUI/PogoLocationFeeder.GUI.csproj
@@ -632,6 +632,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <WCFMetadata Include="Service References\" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Fody.1.29.4\build\dotnet\Fody.targets" Condition="Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/PogoLocationFeeder.sln
+++ b/PogoLocationFeeder.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PogoLocationFeederTests", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PogoLocationFeeder.GUI", "PogoLocationFeeder.GUI\PogoLocationFeeder.GUI.csproj", "{D6536900-0B51-454E-AC1E-87EF86CCE31B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PogoLocationFeeder.API", "PogoLocationFeeder.API\PogoLocationFeeder.API.csproj", "{E82FE137-7326-4EFA-A4DD-A8592BF70F36}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{D6536900-0B51-454E-AC1E-87EF86CCE31B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D6536900-0B51-454E-AC1E-87EF86CCE31B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D6536900-0B51-454E-AC1E-87EF86CCE31B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E82FE137-7326-4EFA-A4DD-A8592BF70F36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E82FE137-7326-4EFA-A4DD-A8592BF70F36}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E82FE137-7326-4EFA-A4DD-A8592BF70F36}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E82FE137-7326-4EFA-A4DD-A8592BF70F36}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/PogoLocationFeeder/PogoLocationFeeder.csproj
+++ b/PogoLocationFeeder/PogoLocationFeeder.csproj
@@ -132,7 +132,9 @@
     <None Include="Config\discord_channels.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/PogoLocationFeederTests/Api/PogoLocationFeederListenerTests.cs
+++ b/PogoLocationFeederTests/Api/PogoLocationFeederListenerTests.cs
@@ -1,0 +1,132 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PogoLocationFeeder.Api.Tests
+{
+    [TestClass()]
+    public class PogoLocationFeederListenerTests
+    {
+        const int port = 16959;
+        TcpListener listener;
+        private List<TcpClient> arrSocket = new List<TcpClient>();
+
+        [TestInitialize]
+        public void Setup()
+        {
+            Task.Run(() =>
+            {
+                try
+                {
+                    listener = new TcpListener(IPAddress.Any, port);
+                    listener.Start();
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine($"Could open port {port}", e);
+                    throw e;
+                }
+                listener.BeginAcceptTcpClient(HandleAsyncConnection, listener);
+            });
+        }
+
+        List<SniperInfoModel> receivedSniperInfos = new List<SniperInfoModel>();
+
+        [TestMethod()]
+        public void AsyncStartTest()
+        {
+            PogoLocationFeederListener pogoLocationFeederListener =  new PogoLocationFeederListener();
+            pogoLocationFeederListener.eventHandler += (sender, sniperInfo) =>
+            {
+                //Implement your code here
+                System.Console.WriteLine("SniperInfo received");
+                receivedSniperInfos.Add(sniperInfo);
+            };
+            pogoLocationFeederListener.AsyncStart("localhost", port);
+            Thread.Sleep(500);
+            SendToClients(createSniperInfo());
+            Thread.Sleep(100);
+            Assert.IsTrue(receivedSniperInfos.Any());
+            Assert.AreEqual(POGOProtos.Enums.PokemonId.Abra, receivedSniperInfos[0].Id);
+            Assert.AreEqual(12.345, receivedSniperInfos[0].Latitude);
+            Assert.AreEqual(-98.765, receivedSniperInfos[0].Longitude);
+            Assert.AreEqual(95.6, receivedSniperInfos[0].IV);
+        }
+
+        private SniperInfo createSniperInfo()
+        {
+            SniperInfo sniperInfo = new SniperInfo();
+            sniperInfo.Id = POGOProtos.Enums.PokemonId.Abra;
+            sniperInfo.Latitude = 12.345;
+            sniperInfo.Longitude = -98.765;
+            sniperInfo.IV = 95.6;
+            return sniperInfo;
+        }
+
+        private void StartAccept()
+        {
+            listener.BeginAcceptTcpClient(HandleAsyncConnection, listener);
+        }
+
+        private void HandleAsyncConnection(IAsyncResult res)
+        {
+            StartAccept();
+            TcpClient client = listener.EndAcceptTcpClient(res);
+            if (client != null && IsConnected(client.Client))
+            {
+                arrSocket.Add(client);
+                Console.WriteLine($"New connection");
+            }
+        }
+
+        public static bool IsConnected(Socket client)
+        {
+            // This is how you can determine whether a socket is still connected.
+            bool blockingState = client.Blocking;
+
+            try
+            {
+                byte[] tmp = new byte[1];
+
+                client.Blocking = false;
+                client.Send(tmp, 0, 0);
+                return true;
+            }
+            catch (SocketException e)
+            {
+                // 10035 == WSAEWOULDBLOCK
+                return (e.NativeErrorCode.Equals(10035));
+            }
+            finally
+            {
+                client.Blocking = blockingState;
+            }
+        }
+
+        private void SendToClients(SniperInfo sniperInfo)
+        {
+            foreach (var socket in arrSocket) // Repeat for each connected client (socket held in a dynamic array)
+            {
+                try
+                {
+                    NetworkStream networkStream = socket.GetStream();
+                    StreamWriter s = new StreamWriter(networkStream);
+
+                    s.WriteLine(JsonConvert.SerializeObject(sniperInfo));
+                    s.Flush();
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine($"Caught exception: {e.ToString()}");
+                }
+            }
+        }
+    }
+}

--- a/PogoLocationFeederTests/PogoLocationFeederTests.csproj
+++ b/PogoLocationFeederTests/PogoLocationFeederTests.csproj
@@ -36,6 +36,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="POGOProtos, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\POGOProtos.1.4.0\lib\net45\POGOProtos.dll</HintPath>
@@ -55,6 +59,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="Api\PogoLocationFeederListenerTests.cs" />
     <Compile Include="Tests\GeoCoordinatesParserTest.cs" />
     <Compile Include="Tests\IVParserTests.cs" />
     <Compile Include="Tests\MessageCacheTests.cs" />
@@ -65,6 +70,10 @@
     <Compile Include="Tests\TrackemonRarePokemonRepositoryTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\PogoLocationFeeder.API\PogoLocationFeeder.API.csproj">
+      <Project>{E82FE137-7326-4EFA-A4DD-A8592BF70F36}</Project>
+      <Name>PogoLocationFeeder.API</Name>
+    </ProjectReference>
     <ProjectReference Include="..\PogoLocationFeeder\PogoLocationFeeder.csproj">
       <Project>{76F6EEEF-E89F-4E43-AA9D-1567CBC1420B}</Project>
       <Name>PogoLocationFeeder</Name>
@@ -72,6 +81,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/PogoLocationFeederTests/app.config
+++ b/PogoLocationFeederTests/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/PogoLocationFeederTests/packages.config
+++ b/PogoLocationFeederTests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
I've added an API project which builds a DLL to allow other projects to listen to a PogoLocationServer.

The goal was to create a simple API to allows a client to connect without much knowledge.
Example:
```
using PogoLocationFeeder.Api;
...
PogoLocationFeederListener` pogoLocationFeederListener =  new PogoLocationFeederListener();
pogoLocationFeederListener.eventHandler += (sender, sniperInfo) =>
{
    //Implement your code here
};`
pogoLocationFeederListener.AsyncStart("localhost", port);
```

Required references (not included):
Newtonsoft.Json
POGOProtos

If we later add an API to allow client to send us their pokémon encounters, this could be added in the same project.

If someone has time to create a Nuget package for this dll before the next release, that would be highly appreciated.

Feedback from other devs would be highly appreciated.