### PR TITLE
UsePokeSnipers and UseTrackemon are now set to true by default

### DIFF
--- a/PogoLocationFeeder/Config/Settings.cs
+++ b/PogoLocationFeeder/Config/Settings.cs
@@ -19,8 +19,8 @@ namespace PogoLocationFeeder.Config
         public static bool Gui = false;
         public static IOutput Output;
         public static int Port = 16969;
-        public static bool UsePokeSnipers = false;
-        public static bool UseTrackemon = false;
+        public static bool UsePokeSnipers = true;
+        public static bool UseTrackemon = true;
         public static string PokeSnipers2Exe = "";
         public static int RemoveAfter = 15;
         public static int ShowLimit = 30;


### PR DESCRIPTION
First run generated `config.json` now contains `UsePokeSnipers` and `UseTrackemon` set to true by default.

Fixes #217 