### PR TITLE
Add LatLngBounds Filter

### DIFF
--- a/PogoLocationFeeder.GUI/MainWindow.xaml
+++ b/PogoLocationFeeder.GUI/MainWindow.xaml
@@ -10,7 +10,7 @@
                       BorderBrush="{DynamicResource AccentColorBrush}"
                       BorderThickness="1"
                       WindowStartupLocation="CenterScreen"
-                      Title="Location Feeder" MinHeight="450" MinWidth="750" Height="450" Width="850"
+                      Title="Location Feeder" MinHeight="450" MinWidth="750" Height="600" Width="850"
                       xmlns:views1="clr-namespace:PogoLocationFeeder.GUI.Views"
                       TitleCaps="False"
                       NonActiveWindowTitleBrush="{DynamicResource HighlightBrush}"

--- a/PogoLocationFeeder.GUI/ViewModels/MainWindowViewModel.cs
+++ b/PogoLocationFeeder.GUI/ViewModels/MainWindowViewModel.cs
@@ -38,6 +38,7 @@ using PogoLocationFeeder.GUI.Models;
 using PogoLocationFeeder.GUI.Properties;
 using PogoLocationFeeder.Input;
 using PropertyChanged;
+using PogoLocationFeeder.Helper;
 
 //using POGOProtos.Enums;
 
@@ -126,6 +127,8 @@ namespace PogoLocationFeeder.GUI.ViewModels
         public string RemoveMinutes { get; set; }
         public bool UseSkiplagged { get; set; }
         public bool UseFilter { get; set; }
+        public bool UseGeoLocationBoundsFilter { get; set; }
+        public LatLngBounds GeoLocationBounds { get; set; }
 
         public PokemonFilterModel SelectedPokemonFilter { get; set; }
         public PokemonFilterModel SelectedPokemonFiltered { get; set; }
@@ -197,6 +200,8 @@ namespace PogoLocationFeeder.GUI.ViewModels
             UseSkiplagged = GlobalSettings.VerifyOnSkiplagged;
             RemoveMinutes = GlobalSettings.RemoveAfter.ToString();
             UseFilter = GlobalSettings.UseFilter;
+            UseGeoLocationBoundsFilter = GlobalSettings.UseGeoLocationBoundsFilter;
+            GeoLocationBounds = GlobalSettings.GeoLocationBounds;
             AppThemeText = GlobalSettings.AppTheme;
             TransitionerIndex = 1;
 
@@ -220,6 +225,8 @@ namespace PogoLocationFeeder.GUI.ViewModels
             GlobalSettings.RemoveAfter = int.Parse(RemoveMinutes);
             GlobalSettings.VerifyOnSkiplagged = UseSkiplagged;
             GlobalSettings.UseFilter = UseFilter;
+            GlobalSettings.UseGeoLocationBoundsFilter = UseGeoLocationBoundsFilter;
+            GlobalSettings.GeoLocationBounds = GeoLocationBounds;
             GlobalSettings.AppTheme = AppThemeText;
             GlobalSettings.Save();
 

--- a/PogoLocationFeeder.GUI/Views/SettingsView.xaml
+++ b/PogoLocationFeeder.GUI/Views/SettingsView.xaml
@@ -6,7 +6,7 @@
              xmlns:viewmodels="clr-namespace:PogoLocationFeeder.GUI.ViewModels"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              mc:Ignorable="d"
-             d:DesignHeight="500" d:DesignWidth="850"
+             d:DesignHeight="540" d:DesignWidth="850"
              d:DataContext="{d:DesignInstance {x:Type viewmodels:MainWindowViewModel}, IsDesignTimeCreatable=False}">
     <Grid>
         <Grid.RowDefinitions>
@@ -26,6 +26,12 @@
             <RowDefinition Height="30" />
             <RowDefinition Height="10" />
             <RowDefinition Height="33" />
+            <RowDefinition Height="10" />
+            <RowDefinition Height="33"/>
+            <RowDefinition Height="10" />
+            <RowDefinition Height="33"/>
+            <RowDefinition Height="10" />
+            <RowDefinition Height="33"/>
             <RowDefinition Height="10" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
@@ -87,7 +93,31 @@
 
          <TextBlock Grid.Row="15" Grid.Column="1" VerticalAlignment="Center">Use Filter</TextBlock>
         <ToggleButton Grid.Row="15" Grid.Column="3" HorizontalAlignment="Left" IsChecked="{Binding UseFilter}" VerticalAlignment="Center"></ToggleButton>
-        <Button Grid.Row="17" Grid.Column="3"  Command="{Binding SaveCommand}">Save Settings</Button>
-        
+
+        <TextBlock Grid.Row="17" Grid.Column="1" VerticalAlignment="Center">Use Location Bounds Filter</TextBlock>
+        <ToggleButton Grid.Row="17" Grid.Column="3" HorizontalAlignment="Left" IsChecked="{Binding UseGeoLocationBoundsFilter}" VerticalAlignment="Center"></ToggleButton>
+
+        <TextBlock Grid.Row="19" Grid.Column="1" VerticalAlignment="Center">SouthWest Bounds</TextBlock>
+        <StackPanel Grid.Row="19" Grid.Column="3" DataContext="{Binding GeoLocationBounds}" Orientation="Horizontal">
+            <TextBlock VerticalAlignment="Center">Latitude</TextBlock>
+            <TextBox VerticalAlignment="Center" Text="{Binding SouthWest.Latitude, Mode=TwoWay}" Margin="10, 0"
+                 PreviewTextInput="DoubleValidationTextBox" Width="100" HorizontalAlignment="Left" />
+            <TextBlock VerticalAlignment="Center">Longitude</TextBlock>
+            <TextBox VerticalAlignment="Center" Text="{Binding SouthWest.Longitude, Mode=TwoWay}" Margin="10, 0"
+                 PreviewTextInput="DoubleValidationTextBox" Width="100" HorizontalAlignment="Left" />
+        </StackPanel>
+
+        <TextBlock Grid.Row="21" Grid.Column="1" VerticalAlignment="Center">NorthEast Bounds</TextBlock>
+        <StackPanel Grid.Row="21" Grid.Column="3" DataContext="{Binding GeoLocationBounds}" Orientation="Horizontal">
+            <TextBlock VerticalAlignment="Center">Latitude</TextBlock>
+            <TextBox VerticalAlignment="Center" Text="{Binding NorthEast.Latitude, Mode=TwoWay}" Margin="10, 0"
+                 PreviewTextInput="DoubleValidationTextBox" Width="100" HorizontalAlignment="Left" />
+            <TextBlock VerticalAlignment="Center">Longitude</TextBlock>
+            <TextBox VerticalAlignment="Center" Text="{Binding NorthEast.Longitude, Mode=TwoWay}" Margin="10, 0"
+                 PreviewTextInput="DoubleValidationTextBox" Width="100" HorizontalAlignment="Left" />
+        </StackPanel>
+
+        <Button Grid.Row="23" Grid.Column="3"  Command="{Binding SaveCommand}">Save Settings</Button>
+
     </Grid>
 </UserControl>

--- a/PogoLocationFeeder.GUI/Views/SettingsView.xaml.cs
+++ b/PogoLocationFeeder.GUI/Views/SettingsView.xaml.cs
@@ -60,5 +60,11 @@ namespace PogoLocationFeeder.GUI.Views
                 }
             }
         }
+
+        private void DoubleValidationTextBox(object sender, TextCompositionEventArgs e)
+        {
+            double result;
+            e.Handled = double.TryParse(e.Text, out result);
+        }
     }
 }

--- a/PogoLocationFeeder/Config/Settings.cs
+++ b/PogoLocationFeeder/Config/Settings.cs
@@ -47,6 +47,8 @@ namespace PogoLocationFeeder.Config
         public static bool UsePokezz = true;
         public static bool UsePokemonGoIVClub = true;
         public static bool UseFilter = true;
+        public static bool UseGeoLocationBoundsFilter = false;
+        public static LatLngBounds GeoLocationBounds = new LatLngBounds(new GeoCoordinates(1.237759, 103.608435), new GeoCoordinates(1.471575, 104.044219));
         public static string AppTheme = "Dark";
         public static bool IsServer = false;
         public static bool IsManaged = true;
@@ -94,6 +96,8 @@ namespace PogoLocationFeeder.Config
                 ShowLimit = Math.Max(set.ShowLimit, 1);
                 PokeSnipers2Exe = set.PokeSnipers2Exe;
                 UseFilter = set.UseFilter;
+                UseGeoLocationBoundsFilter = set.UseGeoLocationBoundsFilter;
+                GeoLocationBounds = set.GeoLocationBounds;
                 AppTheme = set.AppTheme;
                 IsServer = set.IsServer;
                 IsManaged = set.IsManaged;
@@ -220,6 +224,11 @@ namespace PogoLocationFeeder.Config
         [DefaultValue(true)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         public bool UseFilter = GlobalSettings.UseFilter;
+        [DefaultValue(false)]
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        public bool UseGeoLocationBoundsFilter = GlobalSettings.UseGeoLocationBoundsFilter;
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
+        public LatLngBounds GeoLocationBounds = GlobalSettings.GeoLocationBounds;
         [DefaultValue("Dark")]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
         public string AppTheme = GlobalSettings.AppTheme;

--- a/PogoLocationFeeder/Helper/GeoCoordinatesParser.cs
+++ b/PogoLocationFeeder/Helper/GeoCoordinatesParser.cs
@@ -16,6 +16,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using PogoLocationFeeder.Common;
 using System;
 using System.Globalization;
 using System.Text.RegularExpressions;
@@ -69,5 +70,70 @@ namespace PogoLocationFeeder.Helper
 
         public double Latitude { get; set; }
         public double Longitude { get; set; }
+    }
+
+    public static class GeoCoordinateValidator
+    {
+        /// <summary>
+        /// Validates the coordinate.
+        /// </summary>
+        /// <param name="latitude">The latitude.</param>
+        /// <param name="longitude">The longitude.</param>
+        /// <returns>True, if the coordinate is valid, false otherwise.</returns>
+        public static bool Validate(double latitude, double longitude)
+        {
+            if (latitude < -90 || latitude > 90) return false;
+            if (longitude < -180 || longitude > 180) return false;
+
+            return true;
+        }
+    }
+
+    public class LatLngBounds
+    {
+        public LatLngBounds()
+        {
+            this.SouthWest = new GeoCoordinates();
+            this.NorthEast = new GeoCoordinates();
+        }
+
+        public LatLngBounds(GeoCoordinates sw, GeoCoordinates ne)
+        {
+            this.SouthWest = sw;
+            this.NorthEast = ne;
+        }
+
+        public GeoCoordinates SouthWest { get; set; }
+        public GeoCoordinates NorthEast { get; set; }
+
+        /// <summary>
+        /// Determine if Lat/Lng in Bounds
+        /// </summary>
+        /// <param name="pointLat">The Latitude point to test</param>
+        /// <param name="pointLng">The Longitude point to test</param>
+        /// <returns>Returns whether this contains the given LatLng.</returns>
+        public bool Intersects(double pointLat, double pointLng)
+        {
+            var sw = this.SouthWest;
+            var ne = this.NorthEast;
+
+            //simple check       
+            if ((pointLat >= sw.Latitude && pointLat <= ne.Latitude) && (pointLng >= sw.Longitude && pointLng <= ne.Longitude))
+                return true;
+
+            //advance check
+            bool eastBound = pointLng < ne.Longitude;
+            bool westBound = pointLng > sw.Longitude;
+
+            bool inLong = (ne.Longitude < sw.Longitude) ? (eastBound || westBound) : (eastBound && westBound);
+            bool inLat = pointLat > sw.Latitude && pointLat < ne.Latitude;
+
+            if (!(inLat && inLong))
+            {
+                Log.Info($"SnipeInfo Lat \"{pointLat}\", Lng \"{pointLat}\" not in bounds.");
+            }
+
+            return (inLat && inLong);
+        }
     }
 }

--- a/PogoLocationFeeder/Program.cs
+++ b/PogoLocationFeeder/Program.cs
@@ -304,7 +304,9 @@ namespace PogoLocationFeeder
                 sniperInfosToSend =
                     SkipLaggedPokemonLocationValidator.Instance.FilterNonAvailableAndUpdateMissingPokemonId(sniperInfosToSend);
                 sniperInfosToSend = sniperInfosToSend.Where(
-                    i =>!GlobalSettings.UseFilter || GlobalSettings.PokekomsToFeedFilter.Contains(i.Id.ToString())).ToList();
+                    i => !GlobalSettings.UseFilter || GlobalSettings.PokekomsToFeedFilter.Contains(i.Id.ToString())).ToList();
+                sniperInfosToSend = sniperInfosToSend.Where(
+                    i => !GlobalSettings.UseGeoLocationBoundsFilter || GlobalSettings.GeoLocationBounds.Intersects(i.Latitude, i.Longitude)).ToList();
             }
             if (GlobalSettings.VerifiedOnly)
             {


### PR DESCRIPTION
I've added a simple GeoLocation LatLngBounds settings to filtering pokemon's latitude and longitude

Btw, this is the default value in the `PogoLocationFeeder/Config/Settings.cs`
```cs
public static bool UseGeoLocationBoundsFilter = false;
public static LatLngBounds GeoLocationBounds = new LatLngBounds(new GeoCoordinates(1.237759, 103.608435), new GeoCoordinates(1.471575, 104.044219));
```

Looking for better solution to adding map view for this setting.
Your feedback is highly appreciated.