### PR TITLE
Add a view to the snipe area settings on the map

### DIFF
--- a/PogoLocationFeeder.GUI/MainWindow.xaml
+++ b/PogoLocationFeeder.GUI/MainWindow.xaml
@@ -41,6 +41,7 @@
             <views1:SettingsView />
             <views1:DebugOutputView />
             <views1:FilterView />
+            <views1:LatLngSettingView />
         </materialDesign:Transitioner>
         <Grid Grid.Row="1" Margin="4,0">
             <Grid.ColumnDefinitions>

--- a/PogoLocationFeeder.GUI/PogoLocationFeeder.GUI.csproj
+++ b/PogoLocationFeeder.GUI/PogoLocationFeeder.GUI.csproj
@@ -123,6 +123,9 @@
     <Compile Include="Views\FilterView.xaml.cs">
       <DependentUpon>FilterView.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\LatLngSettingView.xaml.cs">
+      <DependentUpon>LatLngSettingView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\MainView.xaml.cs">
       <DependentUpon>MainView.xaml</DependentUpon>
     </Compile>
@@ -146,6 +149,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\FilterView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\LatLngSettingView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -359,6 +366,11 @@
   </ItemGroup>
   <ItemGroup>
     <Resource Include="Feeder.ico" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="static\map.html">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <UsingTask TaskName="CosturaCleanup" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll" TaskFactory="CodeTaskFactory">

--- a/PogoLocationFeeder.GUI/ViewModels/MainWindowViewModel.cs
+++ b/PogoLocationFeeder.GUI/ViewModels/MainWindowViewModel.cs
@@ -61,6 +61,8 @@ namespace PogoLocationFeeder.GUI.ViewModels
             DebugComand = new ActionCommand(ShowDebug);
             RemovePathCommand = new ActionCommand(RemovePath);
             SaveCommand = new ActionCommand(SaveClick);
+            LatLngSettingCommand = new ActionCommand(ShowLatLngSettings);
+            SaveLatLngSettingCommand = new ActionCommand(SaveLatLngSettingClick);
             PayPalCommand = new ActionCommand(OpenPaypal);
             BitcoinCommand = new ActionCommand(OpenBitcoin);
             FilterCommand = new ActionCommand(ShowFilter);
@@ -105,6 +107,8 @@ namespace PogoLocationFeeder.GUI.ViewModels
         public ICommand StartStopCommand { get; }
         public ICommand RemovePathCommand { get; }
         public ICommand SaveCommand { get; }
+        public ICommand LatLngSettingCommand { get; }
+        public ICommand SaveLatLngSettingCommand { get; } 
         public ICommand PayPalCommand { get; }
         public ICommand BitcoinCommand { get; }
         public ICommand FilterCommand { get; }
@@ -129,12 +133,21 @@ namespace PogoLocationFeeder.GUI.ViewModels
         public bool UseFilter { get; set; }
         public bool UseGeoLocationBoundsFilter { get; set; }
         public LatLngBounds GeoLocationBounds { get; set; }
+        public LatLngBounds LocationBoundsSettingToSave { get; set; }
 
         public PokemonFilterModel SelectedPokemonFilter { get; set; }
         public PokemonFilterModel SelectedPokemonFiltered { get; set; }
         public int IndexPokemonToFilter { get; set; }
         public SolidColorBrush SortAlphaActive { get; set; }
         public SolidColorBrush SortIdActive { get; set; } = new SolidColorBrush(Colors.DimGray);
+
+        public Visibility MapViewVisibility
+        {
+            get
+            {
+                return (TransitionerIndex == 4) ? Visibility.Visible : Visibility.Collapsed;
+            }
+        }
 
         public Visibility ColVisibility
         {
@@ -187,7 +200,7 @@ namespace PogoLocationFeeder.GUI.ViewModels
 
         public void ShowSettings()
         {
-            if (TransitionerIndex != 0)
+            if (TransitionerIndex != 0 && TransitionerIndex != 4)
             {
                 TransitionerIndex = 0;
                 return;
@@ -231,6 +244,25 @@ namespace PogoLocationFeeder.GUI.ViewModels
             GlobalSettings.Save();
 
             GlobalSettings.Output.RemoveListExtras();
+        }
+
+        public void ShowLatLngSettings()
+        {
+            if (TransitionerIndex != 1)
+            {
+                TransitionerIndex = 1;
+                return;
+            }            
+            GlobalSettings.Load();
+            LocationBoundsSettingToSave = GlobalSettings.GeoLocationBounds;
+            TransitionerIndex = 4;
+        }
+
+        public void SaveLatLngSettingClick()
+        {
+            GlobalSettings.GeoLocationBounds = LocationBoundsSettingToSave;
+            GlobalSettings.Save();
+            ShowSettings();
         }
 
         public void ShowDebug()

--- a/PogoLocationFeeder.GUI/Views/LatLngSettingView.xaml
+++ b/PogoLocationFeeder.GUI/Views/LatLngSettingView.xaml
@@ -1,0 +1,65 @@
+﻿<UserControl x:Class="PogoLocationFeeder.GUI.Views.LatLngSettingView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:viewmodels="clr-namespace:PogoLocationFeeder.GUI.ViewModels"
+             mc:Ignorable="d"
+             d:DesignHeight="540" d:DesignWidth="850"
+             d:DataContext="{d:DesignInstance {x:Type viewmodels:MainWindowViewModel}, IsDesignTimeCreatable=False}" >
+    <DockPanel>
+        <Grid DockPanel.Dock="Left">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="16" />
+                <RowDefinition Height="30" />
+                <RowDefinition Height="10" />
+                <RowDefinition Height="30" />
+                <RowDefinition Height="10" />
+                <RowDefinition Height="30" />
+                <RowDefinition Height="10" />
+                <RowDefinition Height="30" />
+                <RowDefinition Height="10" />
+                <RowDefinition Height="30" />
+                <RowDefinition Height="10" />
+                <RowDefinition Height="30" />
+                <RowDefinition Height="10" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="10" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="20" />
+                <ColumnDefinition />
+                <ColumnDefinition Width="5"/>
+            </Grid.ColumnDefinitions>
+
+            <Label Grid.Row="1"  Grid.Column="1" HorizontalAlignment="Center" Content="SouthWest" FontWeight="Bold" FontSize="16"></Label>
+
+            <TextBlock Grid.Row="3" Grid.Column="1" VerticalAlignment="Center">Latitude</TextBlock>
+            <TextBox Grid.Row="3" Grid.Column="3" VerticalAlignment="Center" Text="{Binding LocationBoundsSettingToSave.SouthWest.Latitude, Mode=TwoWay}"
+                 PreviewTextInput="DoublelValidationTextBox" Width="100" HorizontalAlignment="Left" />
+
+            <TextBlock Grid.Row="5" Grid.Column="1" VerticalAlignment="Center">Longitude</TextBlock>
+            <TextBox Grid.Row="5" Grid.Column="3" VerticalAlignment="Center" Text="{Binding LocationBoundsSettingToSave.SouthWest.Longitude, Mode=TwoWay}"
+                 PreviewTextInput="DoublelValidationTextBox" Width="100" HorizontalAlignment="Left" />
+
+            <Label Grid.Row="7" Grid.Column="1" HorizontalAlignment="Center" Content="NorthEast" FontWeight="Bold" FontSize="16"></Label>
+
+            <TextBlock Grid.Row="9" Grid.Column="1" VerticalAlignment="Center">Latitude</TextBlock>
+            <TextBox Grid.Row="9" Grid.Column="3" VerticalAlignment="Center" Text="{Binding LocationBoundsSettingToSave.NorthEast.Latitude, Mode=TwoWay}"
+                 PreviewTextInput="DoublelValidationTextBox" Width="100" HorizontalAlignment="Left" />
+
+            <TextBlock Grid.Row="11" Grid.Column="1" VerticalAlignment="Center">Longitude</TextBlock>
+            <TextBox Grid.Row="11" Grid.Column="3" VerticalAlignment="Center" Text="{Binding LocationBoundsSettingToSave.NorthEast.Longitude, Mode=TwoWay}"
+                 PreviewTextInput="DoublelValidationTextBox" Width="100" HorizontalAlignment="Left" />
+
+            <StackPanel Grid.Row="13" Grid.Column="3" Orientation="Horizontal"/>
+            <WrapPanel Grid.Column="1" HorizontalAlignment="Left" Height="41" Margin="2,4,0,0" Grid.Row="13" VerticalAlignment="Top" Width="223" Grid.ColumnSpan="3">
+                <Button Command="{Binding SaveLatLngSettingCommand}" Content="Save" Width="100" Margin="5,5"/>
+                <Button Command="{Binding SettingsComand}" Content="Back" Width="100" />
+            </WrapPanel>
+
+        </Grid>
+        <WebBrowser DockPanel.Dock="Right" Visibility="{Binding MapViewVisibility}" Loaded="setupObjectForScripting" Name="webBrowser1" MinHeight="360" Width="Auto" Margin="5, 5" />
+    </DockPanel>
+</UserControl>

--- a/PogoLocationFeeder.GUI/Views/LatLngSettingView.xaml.cs
+++ b/PogoLocationFeeder.GUI/Views/LatLngSettingView.xaml.cs
@@ -1,0 +1,68 @@
+﻿/*
+PogoLocationFeeder gathers pokemon data from various sources and serves it to connected clients
+Copyright (C) 2016  PogoLocationFeeder Development Team <admin@pokefeeder.live>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Windows.Forms;
+using System.Windows.Input;
+using PogoLocationFeeder.Common;
+using PogoLocationFeeder.Config;
+using PogoLocationFeeder.GUI.Properties;
+using UserControl = System.Windows.Controls.UserControl;
+using PogoLocationFeeder.Helper;
+using System.Security.Permissions;
+
+namespace PogoLocationFeeder.GUI.Views
+{
+    /// <summary>
+    /// Interaction logic for LatLngSettingView.xaml
+    /// </summary>
+    public partial class LatLngSettingView : UserControl
+    {
+        public LatLngSettingView()
+        {
+            InitializeComponent();
+            Uri uri = new Uri(AppDomain.CurrentDomain.BaseDirectory + "static/map.html");
+            webBrowser1.Navigate(uri);
+        }
+
+        private void DoublelValidationTextBox(object sender, TextCompositionEventArgs e)
+        {
+            double result;
+            e.Handled = double.TryParse(e.Text, out result);
+        }
+
+        private void setupObjectForScripting(object sender, System.Windows.RoutedEventArgs e)
+        {            
+            webBrowser1.ObjectForScripting = new HtmlInteropInternalClass();
+        }
+                
+        // Object used for communication from JS -> WPF
+        [System.Runtime.InteropServices.ComVisibleAttribute(true)]
+        public class HtmlInteropInternalClass
+        {
+            public void setMapInfo(double lat, double lng, double swLat, double swLng, double neLat, double neLng)
+            {
+                var sw = new GeoCoordinates(swLat, swLng);
+                var ne = new GeoCoordinates(neLat, neLng);
+                ViewModels.MainWindowViewModel.Instance.LocationBoundsSettingToSave = new LatLngBounds(sw, ne);
+            }
+        }
+    }
+}

--- a/PogoLocationFeeder.GUI/Views/SettingsView.xaml
+++ b/PogoLocationFeeder.GUI/Views/SettingsView.xaml
@@ -95,8 +95,11 @@
         <ToggleButton Grid.Row="15" Grid.Column="3" HorizontalAlignment="Left" IsChecked="{Binding UseFilter}" VerticalAlignment="Center"></ToggleButton>
 
         <TextBlock Grid.Row="17" Grid.Column="1" VerticalAlignment="Center">Use Location Bounds Filter</TextBlock>
-        <ToggleButton Grid.Row="17" Grid.Column="3" HorizontalAlignment="Left" IsChecked="{Binding UseGeoLocationBoundsFilter}" VerticalAlignment="Center"></ToggleButton>
-
+        <StackPanel Grid.Row="17" Grid.Column="3" Orientation="Horizontal">
+            <ToggleButton HorizontalAlignment="Left" IsChecked="{Binding UseGeoLocationBoundsFilter}" VerticalAlignment="Center"></ToggleButton>
+            <Button Command="{Binding LatLngSettingCommand}" Content="Browse" Margin="10, 0" />
+        </StackPanel>
+        
         <TextBlock Grid.Row="19" Grid.Column="1" VerticalAlignment="Center">SouthWest Bounds</TextBlock>
         <StackPanel Grid.Row="19" Grid.Column="3" DataContext="{Binding GeoLocationBounds}" Orientation="Horizontal">
             <TextBlock VerticalAlignment="Center">Latitude</TextBlock>

--- a/PogoLocationFeeder.GUI/static/map.html
+++ b/PogoLocationFeeder.GUI/static/map.html
@@ -1,0 +1,78 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>PogoLocationFeeder GUI Google Maps</title>
+    
+    <style>
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+            overflow: hidden;
+        }
+
+        #map_canvas {
+            height: 100%;
+            border: 1px groove #eee;
+        }
+    </style>
+    
+    <script type="text/javascript" src="http://maps.googleapis.com/maps/api/js"></script>
+
+</head>
+<body>
+
+    <div id="map_canvas"></div>
+
+    <script type="text/javascript">
+        //Definition of global variables
+        var map = null,
+            timer = null;
+                
+        //initialize of Google map output
+        function initialize() {
+
+            //variables
+            var canvas, latlng;
+
+            //map element
+            canvas = document.getElementById('map_canvas');
+
+            //default center latlng
+            latlng = new google.maps.LatLng(1.3308656, 103.9086102);
+
+            //Create an instance of the Map class
+            map = new google.maps.Map(canvas, {
+                center: latlng,
+                mapTypeId: google.maps.MapTypeId.ROADMAP,
+                zoom: 12,
+                disableDefaultUI: false, //true,
+                zoomControl: true
+            });
+            
+            //bind map idle event
+            google.maps.event.addListener(map, 'idle', function () {
+                var latLng = map.getCenter();
+                var latLngBounds = map.getBounds();
+                var lat = latLng.lat();
+                var lng = latLng.lng();
+                var swLat = latLngBounds.getSouthWest().lat();
+                var swLng = latLngBounds.getSouthWest().lng();
+                var neLat = latLngBounds.getNorthEast().lat();
+                var neLng = latLngBounds.getNorthEast().lng();
+                //console.log(lat, lng, swLat, swLng, neLat, neLng);
+                //invoke WPF InteropServices
+                window.external.setMapInfo(lat, lng, swLat, swLng, neLat, neLng);                
+            });
+        }
+        
+        //Initialize on page loaded
+        google.maps.event.addDomListener(window, 'load', initialize);
+
+    </script>
+
+</body>
+</html> 

--- a/PogoLocationFeeder/Common/GeoCoordinates.cs
+++ b/PogoLocationFeeder/Common/GeoCoordinates.cs
@@ -38,6 +38,16 @@ namespace PogoLocationFeeder.Common
 
             return true;
         }
+
+        public static bool Validate(GeoCoordinates latLng)
+        {
+            return Validate(latLng.Latitude, latLng.Longitude);
+        }
+
+        public static bool Validate(LatLngBounds bounds)
+        {
+            return (Validate(bounds.SouthWest) && Validate(bounds.NorthEast));
+        }
     }
 
     public class LatLngBounds


### PR DESCRIPTION
Small feature for [917a066](https://github.com/5andr0/PogoLocationFeeder/commit/917a066445f32422be173e0023cf224a8a800678), a user can set the SW/NE latitude and longitude bounds area through the map instead of manually enter.
- Lat long bounds will be updated on google map idle event fired, implemented with WebBrowser. ObjectForScripting `System.Runtime.InteropServices`
-  Resize the windows application to get the rectangular area bounds

### GUI
![screencap1](https://cloud.githubusercontent.com/assets/3435332/17760916/bdc853e4-6535-11e6-8763-8471fa1323ce.gif)

### Examples
![screencap1](https://cloud.githubusercontent.com/assets/3435332/17769230/390d7366-656a-11e6-875a-2be6aef00a0b.png)